### PR TITLE
Tag docker image with git commit sha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ script: |
   cargo test &&
   cargo audit &&
   docker build -t alexlauni/liftright-data-server -f Dockerfile . 
-after_success: |
-  cargo tarpaulin --ignore-tests
+
+after_success: 
+- cargo tarpaulin --ignore-tests
+- echo $(git rev-parse --short HEAD)
 
 deploy:
   provider: script
-  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; docker push alexlauni/liftright-data-server
+  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; docker push alexlauni/liftright-data-server:$(git rev-parse --short HEAD)
   on:
     branch: main

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ script: |
 
 after_success: 
 - cargo tarpaulin --ignore-tests
-- echo $(git rev-parse --short HEAD)
 
 deploy:
   provider: script


### PR DESCRIPTION
Tag docker image with HEAD's short SHA before pushing to Docker hub.
Why?
  * Traceability: connects docker image to a git commit
  * GitOps pipeline: allows operator to know when a new image has been posted without excessive metadata parsing
